### PR TITLE
feat: organize model registry with comprehensive model list

### DIFF
--- a/bench/models/model_registry.py
+++ b/bench/models/model_registry.py
@@ -1,20 +1,20 @@
 """
 model ID list for Ko-AgentBench.
-LiteLLM에서 인식 가능한 형식을 사용하세요 (예: 'openai/...', 'anthropic/...', 'groq/...', 'huggingface/...').
+LiteLLM에서 인식 가능한 형식을 사용하세요 (예: 'openai/...', 'anthropic/...', 'groq/...', '...').
 """
 
 from typing import List
 
 MODEL_IDS: List[str] = [
     # Local HuggingFace models
-    "huggingface/Qwen/Qwen3-4B-Instruct-2507",
-    "huggingface/Qwen/Qwen3-8B",
-    "huggingface/skt/A.X-4.0-Light",
-    "huggingface/K-intelligence/Midm-2.0-Base-Instruct",
-    "huggingface/KORMo-Team/KORMo-10B-sft",
-    "huggingface/kakaocorp/kanana-1.5-8b-instruct-2505",
-    "huggingface/dnotitia/DNA-2.0-14B",
-    "huggingface/trillionlabs/Tri-7B",
+    "Qwen/Qwen3-4B-Instruct-2507",
+    "Qwen/Qwen3-8B",
+    "skt/A.X-4.0-Light",
+    "K-intelligence/Midm-2.0-Base-Instruct",
+    "KORMo-Team/KORMo-10B-sft",
+    "kakaocorp/kanana-1.5-8b-instruct-2505",
+    "dnotitia/DNA-2.0-14B",
+    "trillionlabs/Tri-7B",
 
     # Cloud models
     "azure/gpt-5",


### PR DESCRIPTION
## 개요       
주석에 있던 로컬 모델 리스트를 `MODEL_IDS` 리스트로 정리하고, 추가적인 클라우드 모델들을 포함하여 모델 레지스트리를 확장했습니다.                                   
                                                                                     
 ## 주요 변경사항                                                                    
 - 주석에서 로컬 HuggingFace 모델 8개를 `MODEL_IDS` 리스트에 추가                    
 - 클라우드 모델 섹션에 최신 모델들 추가:                                            
   - `azure/gpt-5`                                                                   
   - `anthropic/claude-sonnet-4`                                                     
   - `anthropic/claude-sonnet-4-20250514`                                            
   - `gemini/gemini-2.5-pro`                                                         
   - `gemini/gemini-2.5-flash`                                                       
                                                                                     
 ## 코드 개선사항                                                                    
 - 모델 목록을 논리적 섹션으로 구성 (로컬/클라우드)                                  
 - 명확한 주석 추가로 가독성 향상                                                    
 - 기존 주석 블록 제거로 코드 정리