### PR TITLE
refactor: GracefulFailMetric 개선작업

### DIFF
--- a/bench/runner/metrics.py
+++ b/bench/runner/metrics.py
@@ -470,13 +470,20 @@ class ArgAccMetric(LLMJudgeMetric):
             if not golden_args or not pred_args:
                 return 0.0
 
-            # LLM Judge 호출 (1-5 점수)
-            prompt = f"Golden 인수: {golden_args}\nPredicted 인수: {pred_args}"
+            # 프롬프트 템플릿 사용
+            template = self.prompt_loader.get_prompt("arg_acc")
+            prompt = template.format(
+                golden_args=golden_args,
+                predicted_args=pred_args
+            )
+            
             result = self._call_multi_judge_score(prompt, 'arg_acc', min_score=1, max_score=5)
             
-            # 1-5 점수를 0.0-1.0 범위로 변환
+            # 1-5 점수를 0.0-1.0 범위로 변환 
             score = result.get("score", 1)
-            normalized_score = (score - 1) / 4.0  # 1->0.0, 5->1.0
+            normalized_score = max(0.0, (score - 1) / 4.0)  # 1->0.0, 5->1.0, 음수 방지
+            
+            print(f"DEBUG ArgAcc: score={score}, normalized_score={normalized_score}, result={result}")
             
             return normalized_score
             


### PR DESCRIPTION
## 📋 개요
레벨 5 GracefulFail 메트릭의 평가 로직을 개선하여, 에러를 올바르게 보고하는 케이스를 정확하게 평가할 수 있도록 수정했습니다.

## 🐛 기존 문제점

1. Task success 필드에 의존
에러를 올바르게 보고한 경우도 success=True로 처리됨
이로 인해 Graceful Fail 평가 대상에서 제외됨
2. Fallback 도구 미고려
Fallback 도구가 성공해서 실제 데이터를 제공한 경우와 구분하지 못함
모든 에러 상황을 동일하게 처리
3. 출력 판단 기준 불명확
_has_output() 함수가 에러 메시지와 실제 데이터를 구분하지 못함
에러 메시지도 "출력 있음"으로 간주하여 0점 처리

## ✨ 개선 사항

3단계 평가 로직 도입

1. 주입된 도구 실패 확인
   - tool_calls에서 error_injection.tool의 실제 실패 여부 검증
   - 실패하지 않았으면 평가 대상 아님 (0점)

2. Fallback 도구 성공 여부 확인
   - fallback_options의 도구가 성공했는지 검증
   - 성공했으면 실제 데이터를 제공한 것이므로 0점

3. Graceful Fail 판정
   - 주입된 도구 실패 + Fallback 없거나 실패 → 1점
   - 에러를 정중하게 보고하는 것을 Graceful Fail로 인정
   
 ## 리뷰어
 @chelsseeey