### PR TITLE
fix RespOK metric and add resp_schema/arg_schema 

### DIFF
--- a/bench/runner/metrics.py
+++ b/bench/runner/metrics.py
@@ -540,7 +540,8 @@ class RespOKMetric(Metric):
 
     @staticmethod
     def _extract_candidate(ctx: EvalContext):
-        cand = ctx.logs.get("actual_output")
+        # final_response를 확인
+        cand = ctx.logs.get("final_response")
 
         if isinstance(cand, (str, dict, list)):
             return cand

--- a/evaluate_model_run.py
+++ b/evaluate_model_run.py
@@ -195,7 +195,7 @@ class ModelRunEvaluator:
             if self.verbose:
                 print(f"  [{idx}/{len(tasks_to_evaluate)}] {task_id}")
 
-            # task_schema 구성
+            # task_schema 구성 
             task_schema = {
                 "task_id": task_result.get("task_id"),
                 "instruction": task_result.get("instruction"),
@@ -208,6 +208,7 @@ class ModelRunEvaluator:
                 "error_injection": task_result.get("error_injection"),
                 "fallback_options": task_result.get("fallback_options", []),
                 "resp_schema": task_result.get("resp_schema"),
+                "arg_schema": task_result.get("arg_schema"),
             }
 
             # logs 구성

--- a/run_benchmark_with_logging.py
+++ b/run_benchmark_with_logging.py
@@ -174,6 +174,8 @@ def simplify_result(result: Dict[str, Any]) -> Dict[str, Any]:
         "data_flow": result.get("data_flow", []),
         "error_injection": result.get("error_injection"),
         "fallback_options": result.get("fallback_options", []),
+        "resp_schema": result.get("resp_schema", {}),
+        "arg_schema": result.get("arg_schema", {}),
         "token_usage": result.get("token_usage", {
             "prompt_tokens": 0,
             "completion_tokens": 0,
@@ -505,6 +507,11 @@ def run_benchmark_on_dataset(
             # Include fallback_options for L5 tasks
             if 'fallback_options' in task:
                 result['fallback_options'] = task.get('fallback_options')
+            # Include resp_schema and arg_schema for evaluation
+            if 'expected_output' in task:
+                result['resp_schema'] = task.get('expected_output', {})
+            if 'arg_schema' in task:
+                result['arg_schema'] = task.get('arg_schema', {})
             all_results.append(result)
             
             # Print summary


### PR DESCRIPTION
[RespOK 결과가 모두 0.000으로 나오는 문제 해결]

 1) 존재하지 않는 “actual_output”→ “final_response”를 확인하도록 수정
 2) 벤치마크 실행 시 로그에 resp_schema와 arg_schema 포함하도록 수정