### PR TITLE
Add AdaptiveRoutingScore metric for L5 robustness reports

### DIFF
--- a/bench/runner/prompts.yaml
+++ b/bench/runner/prompts.yaml
@@ -60,45 +60,6 @@ arg_acc:
     좋은 예: "모든 인수가 의미적으로 동등합니다. 좌표값은 소수점 자릿수만 다를 뿐 동일 위치를 나타냅니다."
     나쁜 예: "start: Golden 값 '127.108882,37.394274'와 Predicted 값 '127.1089,37.3943'은 경도는..."
 
-    
-error_detect:
-  system: "You are an expert evaluator for AI error handling."
-  template: |
-    AI 응답이 도구 실행 실패를 사용자에게 명확히 보고하는지 판단하세요.
-
-    주입된 에러:
-    - 도구: {injected_tool}
-    - 에러 타입: {injected_error_type} ({error_type_korean})
-
-    AI의 최종 응답:
-    {final_response}
-
-    판단 기준:
-
-    1. 에러를 보고했는가?
-       - 에러/실패/문제가 발생했다고 명시적으로 언급했는가?
-       - 서비스 이용 불가나 조회 실패를 설명했는가?
-       - 문제의 원인을 설명했는가?
-
-    2. 어떤 타입의 에러를 보고했는가?
-       - timeout: 타임아웃, 시간 초과, 응답 없음, 지연, 연결 시간 초과
-       - data_not_available: 데이터 없음, 조회 불가, 검색 결과 없음, 정보 없음
-       - complete_unavailable: 서비스 불가, 접속 불가, 시스템 장애, 이용 불가
-       - other: 에러는 보고했으나 위 타입에 해당하지 않음
-       - none: 에러 보고하지 않음
-
-    주의사항:
-    - 환각으로 다른 정보를 제공하며 에러를 숨기는 경우: error_reported=false
-    - 에러 언급 없이 "죄송합니다"만 말하는 경우: error_reported=false
-    - 명확하게 에러/실패를 설명하는 경우: error_reported=true
-
-    에러 보고 여부, 보고된 에러 타입, 신뢰도, 그리고 판단 이유를 제공해주세요.
-  
-  error_type_mapping:
-    timeout: "타임아웃/시간 초과"
-    complete_unavailable: "서비스 완전 불가/이용 불가"
-    data_not_available: "데이터 없음/조회 불가"
-
 
 eff_score:
   system: "You are an expert evaluator for task completion."

--- a/evaluate_model_run.py
+++ b/evaluate_model_run.py
@@ -68,9 +68,8 @@ class ModelRunEvaluator:
         'ΔSteps_norm': '최소 경로 대비 효율. 이론적인 최소 호출 횟수 대비 얼마나 효율적인 경로를 생성했는지 평가',
         'Coverage': '소스 커버리지. 정보를 수집해야 하는 여러 소스를 누락 없이 호출했는지 평가',
         'SourceEPR': '소스별 유효 호출 비율. 병렬적으로 호출한 각 도구가 유효했는지 개별적으로 평가',
-        'ErrorDetect': '오류 탐지율. API 호출 실패와 같은 오류 상황을 정확하게 인지하는지 평가',
+        'AdaptiveRoutingScore': '적응형 라우팅 점수. 주입된 도구 실패 이후 얼마나 신속하게 대체 경로로 전환하는지 평가',
         'FallbackSR': '대체 경로 성공률. 특정 도구 실패 시 다른 도구를 활용해 성공하는 비율',
-        'GracefulFail': '안전한 실패 비율. 오류 발생 시 환각 없이 실패를 인정하거나 사용자에게 알리는지 평가',
         'EffScore': '효율 점수. 이론적 최소 호출 수와 재사용률을 종합하여 효율성을 점수화',
         'RedundantCallRate': '불필요 호출 비율. 정보를 이미 알고 있음에도 불필요하게 도구를 다시 호출하는 비율',
         'ReuseRate': '재사용 비율. 이전에 호출했던 결과를 재호출 없이 효율적으로 재사용하는 비율',
@@ -120,7 +119,6 @@ class ModelRunEvaluator:
         judge_metrics = [
             'SR',               # 공통
             'ArgAcc',           # L1
-            'ErrorDetect',      # L5
             'EffScore',         # L6
             'ContextRetention', # L7
             'RefRecall'         # L7
@@ -237,7 +235,7 @@ class ModelRunEvaluator:
             logs = {
                 "success": task_result.get("success", False),
                 "tool_invocations": task_result.get("tool_calls", []),
-                "tool_calls": task_result.get("tool_calls", []),  # ErrorDetectMetric용
+                "tool_calls": task_result.get("tool_calls", []),  # AdaptiveRoutingScore/FallbackSR 평가용
                 "actual_output": task_result.get("final_response", ""),
                 "final_response": task_result.get("final_response", ""),
                 "conversation_log": task_result.get("conversation_log", {}),
@@ -474,7 +472,7 @@ class ModelRunEvaluator:
                 'L2': ['SelectAcc'],
                 'L3': ['FSM', 'PSM'],
                 'L4': ['Coverage'],
-                'L5': ['ErrorDetect', 'FallbackSR'],
+                'L5': ['AdaptiveRoutingScore', 'FallbackSR'],
                 'L6': ['EffScore', 'ReuseRate'],
                 'L7': ['ContextRetention']
             }


### PR DESCRIPTION
  - Level 5 평가 지표에서 ErrorDetect, GracefulFail를 제거하고 AdaptiveRoutingScore 메트릭을 새로 도
    입했습니다. 고의로 주입된 오류 이후, 대체 도구로 전환한 첫 단계 간격을 기반으로 점수를 계산해 ARS 평균을 보
    고서에 반영합니다.
  - 평가 파이프라인과 보고서 생성 로직을 모두 업데이트하여 AdaptiveRoutingScore와 FallbackSR 두 지표
    만을 L5 핵심 지표로 표기하도록 정리했습니다.
  - 보고서/요약 파일에서 AdaptiveRoutingScore 값이 정확히 산출되는지 기존 로그로 검증했습니다.

<img width="1554" height="324" alt="image" src="https://github.com/user-attachments/assets/538be8c4-d953-4978-b5ff-dffb4ca63dc8" />
