### PR TITLE
feat: Add result sanitization to CachingExecutor

### DIFF
--- a/bench/tools/caching_executor.py
+++ b/bench/tools/caching_executor.py
@@ -99,10 +99,24 @@ class CachingExecutor:
                 if isinstance(pois_data, dict):
                     poi_list = pois_data.get("poi", [])
                     if isinstance(poi_list, list):
+                        # Create a shallow copy of the result to avoid mutating the original
+                        result = result.copy()
+                        result["searchPoiInfo"] = result["searchPoiInfo"].copy()
+                        result["searchPoiInfo"]["pois"] = result["searchPoiInfo"]["pois"].copy()
+                        
+                        # Create new POI list with sanitized items
+                        sanitized_pois = []
                         for poi in poi_list:
                             if isinstance(poi, dict):
-                                poi.pop("newAddressList", None)
-                                poi.pop("evChargers", None)
+                                # Copy only fields we want to keep (exclude newAddressList, evChargers)
+                                sanitized_poi = {
+                                    k: v for k, v in poi.items() 
+                                    if k not in {"newAddressList", "evChargers"}
+                                }
+                                sanitized_pois.append(sanitized_poi)
+                            else:
+                                sanitized_pois.append(poi)
+                        result["searchPoiInfo"]["pois"]["poi"] = sanitized_pois
         # 2. Market/Finance Tools - Truncate long lists
         elif "MarketList_" in tool_name:  # Upbit, Bithumb
             # For truncation, slicing already creates a new list, no need for extra copy


### PR DESCRIPTION
이 PR은 API 호출 결과를 캐싱하거나 반환할 때, 불필요하게 큰 데이터를 필터링하여 토큰 사용량을 절감하고 캐시 효율을 높이기 위한 변경 사항을 포함합니다.

주요 변경 사항:  
`caching_executor.py`수정: `_sanitize_result` 메서드를 추가하여 툴 실행 결과를 후처리합니다. 
지도/경로 툴 (`Directions_naver`, `Route_tmap` 등): 수백 개의 좌표가 포함된 `path`, `geometry` 등의 필드를 제거하여 응답 크기를 대폭 줄였습니다. 

금융/마켓 툴 (MarketList_*): 수백 개의 종목이 반환되는 경우, 상위 20개 항목만 남기고 나머지는 잘라내도록 처리했습니다.   

기대 효과:  LLM에 전달되는 컨텍스트 길이를 줄여 비용 절감 및 처리 속도 향상. 캐시 파일 용량 최적화.