### PR TITLE
Adjust tool enums for Vertex and add google-auth dependency

### DIFF
--- a/bench/tools/aladin_search.py
+++ b/bench/tools/aladin_search.py
@@ -29,7 +29,7 @@ class AladinAPI(BaseAPI):
     def _search_item(self, query: str, query_type: str = "Keyword", search_target: str = "Book", 
                     start: int = 1, max_results: int = 10, sort: str = "Accuracy", 
                     cover: str = "Mid", category_id: int = 0, output: str = "js", 
-                    out_of_stock_filter: int = 0, opt_result: str = "") -> dict:
+                    out_of_stock_filter: int | str = 0, opt_result: str = "") -> dict:
         """알라딘 상품 검색 API 호출 (내부 구현)
         
         Args:
@@ -48,6 +48,11 @@ class AladinAPI(BaseAPI):
         Returns:
             검색 결과를 포함한 딕셔너리
         """
+        try:
+            out_of_stock_filter = int(out_of_stock_filter)
+        except (TypeError, ValueError):
+            out_of_stock_filter = 0
+
         url = f"{self.base_url}/ItemSearch.aspx"
         params = {
             "ttbkey": self.api_key,
@@ -75,7 +80,7 @@ class AladinAPI(BaseAPI):
                       sub_search_target: str = "", start: int = 1, max_results: int = 10,
                       cover: str = "Mid", category_id: int = 0, year: int = None,
                       month: int = None, week: int = None, output: str = "js",
-                      out_of_stock_filter: int = 0) -> dict:
+                      out_of_stock_filter: int | str = 0) -> dict:
         """알라딘 상품 리스트 조회 API 호출 (내부 구현)
         
         Args:
@@ -95,6 +100,11 @@ class AladinAPI(BaseAPI):
         Returns:
             상품 리스트를 포함한 딕셔너리
         """
+        try:
+            out_of_stock_filter = int(out_of_stock_filter)
+        except (TypeError, ValueError):
+            out_of_stock_filter = 0
+
         url = f"{self.base_url}/ItemList.aspx"
         params = {
             "ttbkey": self.api_key,
@@ -222,10 +232,10 @@ class AladinAPI(BaseAPI):
                             "default": "js"
                         },
                         "out_of_stock_filter": {
-                            "type": "integer",
-                            "enum": [0, 1],
+                            "type": "string",
+                            "enum": ["0", "1"],
                             "description": "품절/절판 상품 필터링 여부 (1: 제외), 기본값: 0",
-                            "default": 0
+                            "default": "0"
                         },
                         "opt_result": {
                             "type": "string",
@@ -312,10 +322,10 @@ class AladinAPI(BaseAPI):
                             "default": "js"
                         },
                         "out_of_stock_filter": {
-                            "type": "integer",
-                            "enum": [0, 1],
+                            "type": "string",
+                            "enum": ["0", "1"],
                             "description": "품절/절판 상품 필터링 여부 (1: 제외), 기본값: 0",
-                            "default": 0
+                            "default": "0"
                         }
                     },
                     "required": ["query_type"]
@@ -477,4 +487,3 @@ if __name__ == "__main__":
         print("알라딘 API 연결 성공")
     else:
         print("알라딘 API 연결 실패")
-

--- a/bench/tools/bithumb_stock.py
+++ b/bench/tools/bithumb_stock.py
@@ -113,7 +113,7 @@ class BithumbStock(BaseAPI):
         return response.json()
 
 
-    def _cryptoCandle_bithumb(self, time: str, count: int = 1, to: str = None, market: str = "KRW-BTC", unit: int = 1) -> Dict[str, Any]:
+    def _cryptoCandle_bithumb(self, time: str, count: int = 1, to: str = None, market: str = "KRW-BTC", unit: int | str = 1) -> Dict[str, Any]:
         """
         시간 및 구간 별 빗썸 거래소 가상자산 가격, 거래량 정보 제공
 
@@ -132,6 +132,10 @@ class BithumbStock(BaseAPI):
         if time not in valid_time:
             return {"error": f"Invalid time. Must be one of {valid_time}"}
         elif time == "minutes":
+            try:
+                unit = int(unit)
+            except (TypeError, ValueError):
+                return {"error": "Invalid unit. Must be a number"}
             valid_units = [1, 3, 5, 10, 15, 30, 60, 240]
             if unit not in valid_units:
                 return {"error": f"Invalid unit. Must be one of {valid_units}"}

--- a/bench/tools/tool_catalog.py
+++ b/bench/tools/tool_catalog.py
@@ -208,7 +208,9 @@ TOOL_CATALOG: Dict[str, Tuple[Type[Any], str, str, Dict[str, Any]]] = {
                 "market": {"type": "string", "default": "KRW-BTC", "description": "마켓 코드"},
                 "count": {"type": "integer", "minimum": 1, "maximum": 200, "default": 1, "description": "캔들 개수"},
                 "to": {"type": "string", "description": "마지막 캔들 시각 (yyyy-MM-dd'T'HH:mm:ss'Z')"},
-                "unit": {"type": "integer", "enum": [1, 3, 5, 10, 15, 30, 60, 240], "default": 1, "description": "분 단위 (time이 minutes일 때만 사용)"}
+                # Vertex function declarations accept enum only for string values.
+                # Keep allowed units as strings and cast back to int in the tool implementation.
+                "unit": {"type": "string", "enum": ["1", "3", "5", "10", "15", "30", "60", "240"], "default": "1", "description": "분 단위 (time이 minutes일 때만 사용)"}
             },
             "required": ["time"]
         }
@@ -263,7 +265,9 @@ TOOL_CATALOG: Dict[str, Tuple[Type[Any], str, str, Dict[str, Any]]] = {
                 "symbol": {"type": "string", "description": "암호화폐 심볼 (비트코인 : BTC, 이더리움 : ETH)"},
                 "quote": {"type": "string", "enum": ["KRW", "BTC", "USDT"], "default": "KRW", "description": "기준 통화 (원화: KRW, 비트코인: BTC, 테더: USDT)"},
                 "candle_type": {"type": "string", "enum": ["minutes", "days", "weeks", "months"], "default": "days", "description": "캔들 타입"},
-                "unit": {"type": "integer", "enum": [1, 3, 5, 10, 15, 30, 60, 240], "description": "분 단위 (candle_type이 minutes일 때만 필요)"},
+                # Vertex function declarations accept enum only for string values.
+                # Keep allowed units as strings and cast back to int in the tool implementation.
+                "unit": {"type": "string", "enum": ["1", "3", "5", "10", "15", "30", "60", "240"], "description": "분 단위 (candle_type이 minutes일 때만 필요)"},
                 "count": {"type": "integer", "minimum": 1, "maximum": 200, "default": 30, "description": "조회할 캔들 개수"},
                 "to": {"type": "string", "description": "마지막 캔들 시각 (YYYY-MM-DD HH:mm:ss)"}
             },
@@ -365,7 +369,9 @@ TOOL_CATALOG: Dict[str, Tuple[Type[Any], str, str, Dict[str, Any]]] = {
                 "cover": {"type": "string", "enum": ["Big", "MidBig", "Mid", "Small", "Mini", "None"], "default": "Mid", "description": "표지 이미지 크기"},
                 "category_id": {"type": "integer", "description": "카테고리 ID"},
                 "output": {"type": "string", "enum": ["xml", "js"], "default": "js", "description": "출력 형식"},
-                "out_of_stock_filter": {"type": "integer", "enum": [0, 1], "default": 0, "description": "품절/절판 상품 필터링 여부 (1: 제외)"},
+                # Vertex AI function declaration enums must be strings, so keep allowed
+                # values as strings even though the downstream API expects 0/1.
+                "out_of_stock_filter": {"type": "string", "enum": ["0", "1"], "default": "0", "description": "품절/절판 상품 필터링 여부 (1: 제외)"},
                 "opt_result": {"type": "string", "description": "부가 정보 요청. 쉼표로 구분하여 다중 선택. (예: ebookList, usedList)"}
             }, 
             "required": ["query"]
@@ -438,10 +444,10 @@ TOOL_CATALOG: Dict[str, Tuple[Type[Any], str, str, Dict[str, Any]]] = {
                     "default": "js"
                 },
                 "out_of_stock_filter": {
-                    "type": "integer",
-                    "enum": [0, 1],
+                    "type": "string",
+                    "enum": ["0", "1"],
                     "description": "품절/절판 상품 필터링 여부 (1: 제외), 기본값: 0",
-                    "default": 0
+                    "default": "0"
                 }
             },
             "required": ["query_type"]

--- a/bench/tools/upbit_crypto.py
+++ b/bench/tools/upbit_crypto.py
@@ -64,12 +64,19 @@ class UpbitCrypto(BaseAPI):
         }
 
     def _crypto_candle(self, symbol: str, quote: str = "KRW",
-                       candle_type: str = "days", unit: Optional[int] = None,
+                       candle_type: str = "days", unit: Optional[int | str] = None,
                        count: int = 30, to: Optional[str] = None) -> Dict[str, Any]:
         """캔들 데이터 조회"""
         market = f"{quote}-{symbol}"
 
         if candle_type == "minutes":
+            try:
+                unit = int(unit) if unit is not None else 1
+            except (TypeError, ValueError):
+                return {"error": "unit must be one of 1,3,5,10,15,30,60,240"}
+            valid_units = {1, 3, 5, 10, 15, 30, 60, 240}
+            if unit not in valid_units:
+                return {"error": "unit must be one of 1,3,5,10,15,30,60,240"}
             url = f"{self.base_url}/v1/candles/minutes/{unit}"
         else:
             url = f"{self.base_url}/v1/candles/{candle_type}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "beautifulsoup4>=4.14.2",
     "boto3>=1.40.55",
     "dotenv>=0.9.9",
+    "google-auth>=2.43.0",
     "ipykernel>=6.30.1",
     "litellm>=1.77.0",
     "pandas>=2.3.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1043,6 +1043,20 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/ef/66d14cf0e01b08d2d51ffc3c20410c4e134a1548fc246a6081eae585a4fe/google_auth-2.43.0.tar.gz", hash = "sha256:88228eee5fc21b62a1b5fe773ca15e67778cb07dc8363adcb4a8827b52d81483", size = 296359, upload-time = "2025-11-06T00:13:36.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/d1/385110a9ae86d91cc14c5282c61fe9f4dc41c0b9f7d423c6ad77038c4448/google_auth-2.43.0-py2.py3-none-any.whl", hash = "sha256:af628ba6fa493f75c7e9dbe9373d148ca9f4399b5ea29976519e0a3848eddd16", size = 223114, upload-time = "2025-11-06T00:13:35.209Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1444,6 +1458,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "dotenv" },
+    { name = "google-auth" },
     { name = "ipykernel" },
     { name = "litellm" },
     { name = "pandas" },
@@ -1459,6 +1474,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
     { name = "boto3", specifier = ">=1.40.55" },
     { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "google-auth", specifier = ">=2.43.0" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "litellm", specifier = ">=1.77.0" },
     { name = "pandas", specifier = ">=2.3.3" },
@@ -2701,6 +2717,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pybase64"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3607,6 +3644,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/24/e3e72d265121e00b063aef3e3501e5b2473cf1b23511d56e529531acf01e/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:94c44ee01fd21c9058f124d2d4f0c9dc7634bec93cd4b38eefc385dabe71acbf", size = 560003, upload-time = "2025-08-27T12:16:08.06Z" },
     { url = "https://files.pythonhosted.org/packages/26/ca/f5a344c534214cc2d41118c0699fffbdc2c1bc7046f2a2b9609765ab9c92/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:df8b74962e35c9249425d90144e721eed198e6555a0e22a563d29fe4486b51f6", size = 590482, upload-time = "2025-08-27T12:16:10.137Z" },
     { url = "https://files.pythonhosted.org/packages/ce/08/4349bdd5c64d9d193c360aa9db89adeee6f6682ab8825dca0a3f535f434f/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:dc23e6820e3b40847e2f4a7726462ba0cf53089512abe9ee16318c366494c17a", size = 556523, upload-time = "2025-08-27T12:16:12.188Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### PR 타이틀
  - Vertex 함수 선언 호환을 위한 도구 입력 검증 및 google-auth 추가

### PR 본문
  - 알라딘 검색/리스트 API: 품절 필터를 문자열 enum으로 노출하고 내부에서 int 캐스팅 및 기본값 처리 추가
  - 업비트/빗썸 캔들 조회: unit을 문자열 입력으로 받고 int 변환·검증 로직 추가
  - tool_catalog: Vertex 함수 선언 제약에 맞춰 분 단위 enum을 문자열로 정의하고 주석으로 제약 설명
  - 의존성: Vertex 호출용 google-auth 추가 (pyproject.toml, uv.lock)